### PR TITLE
Add system-wide memory tracking

### DIFF
--- a/Sources/Footprint/DefaultMemoryProvider.swift
+++ b/Sources/Footprint/DefaultMemoryProvider.swift
@@ -32,15 +32,29 @@ extension Footprint {
             #else
             let remaining: Int64 = kerr == KERN_SUCCESS ? Int64(info.limit_bytes_remaining) : 0
             #endif
+
+            var vmStats = vm_statistics64_data_t()
+            var vmInfoCount = HOST_VM_INFO64_COUNT
+            let vmKerr = withUnsafeMutablePointer(to: &vmStats) {
+                $0.withMemoryRebound(to: integer_t.self, capacity: Int(vmInfoCount)) {
+                    host_statistics64(mach_host_self(), HOST_VM_INFO64, $0, &vmInfoCount)
+                }
+            }
+            let systemLimit = Int64(ProcessInfo.processInfo.physicalMemory)
+            let systemRemaining: Int64 = vmKerr == KERN_SUCCESS ? Int64(UInt64(vmStats.free_count) * UInt64(info.page_size)) : 0
+            let system = Footprint.Memory.System(limit: systemLimit, remaining: systemRemaining)
+
             return Footprint.Memory(
                 used: used,
                 remaining: remaining,
                 compressed: compressed,
-                pressure: pressure
+                pressure: pressure,
+                system: system
             )
         }
 
         private let TASK_BASIC_INFO_COUNT = mach_msg_type_number_t(MemoryLayout<task_basic_info_data_t>.size / MemoryLayout<UInt32>.size)
         private let TASK_VM_INFO_COUNT = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<UInt32>.size)
+        private let HOST_VM_INFO64_COUNT = mach_msg_type_number_t(MemoryLayout<vm_statistics64_data_t>.size / MemoryLayout<UInt32>.size)
     }
 }

--- a/Sources/Footprint/DefaultMemoryProvider.swift
+++ b/Sources/Footprint/DefaultMemoryProvider.swift
@@ -37,11 +37,12 @@ extension Footprint {
             var vmInfoCount = HOST_VM_INFO64_COUNT
             let vmKerr = withUnsafeMutablePointer(to: &vmStats) {
                 $0.withMemoryRebound(to: integer_t.self, capacity: Int(vmInfoCount)) {
-                    host_statistics64(mach_host_self(), HOST_VM_INFO64, $0, &vmInfoCount)
+                    host_statistics64(hostPort, HOST_VM_INFO64, $0, &vmInfoCount)
                 }
             }
+            let pageSize: UInt64 = kerr == KERN_SUCCESS ? UInt64(info.page_size) : UInt64(getpagesize())
             let systemLimit = Int64(ProcessInfo.processInfo.physicalMemory)
-            let systemRemaining: Int64 = vmKerr == KERN_SUCCESS ? Int64(UInt64(vmStats.free_count) * UInt64(info.page_size)) : 0
+            let systemRemaining: Int64 = vmKerr == KERN_SUCCESS ? Int64(UInt64(vmStats.free_count) * pageSize) : 0
             let system = Footprint.Memory.System(limit: systemLimit, remaining: systemRemaining)
 
             return Footprint.Memory(
@@ -51,6 +52,12 @@ extension Footprint {
                 pressure: pressure,
                 system: system
             )
+        }
+
+        private let hostPort: host_t = mach_host_self()
+
+        deinit {
+            mach_port_deallocate(mach_task_self_, hostPort)
         }
 
         private let TASK_BASIC_INFO_COUNT = mach_msg_type_number_t(MemoryLayout<task_basic_info_data_t>.size / MemoryLayout<UInt32>.size)

--- a/Sources/Footprint/Footprint.swift
+++ b/Sources/Footprint/Footprint.swift
@@ -91,18 +91,31 @@ public final class Footprint: @unchecked Sendable {
         /// The time at which this snapshot was taken in monotonic milliseconds of uptime.
         public let timestamp: UInt64
 
+        /// System-wide memory values independent of the app's memory limit.
+        public struct System: Sendable {
+            /// Total physical memory on the device.
+            public let limit: Int64
+            /// Currently free physical memory on the device.
+            public let remaining: Int64
+        }
+
+        /// System-wide memory information.
+        public let system: System
+
         /// Initialize for the `Memory` structure.
         init(
             used: Int64,
             remaining: Int64,
             compressed: Int64 = 0,
-            pressure: State = .normal
+            pressure: State = .normal,
+            system: System = System(limit: 0, remaining: 0)
         ) {
             self.used = used
             self.remaining = remaining
             limit = used + remaining
             self.compressed = compressed
             self.pressure = pressure
+            self.system = system
 
             let usedRatio = limit > 0 ? Double(used) / Double(limit) : 0
             state = usedRatio < 0.25 ? .normal :

--- a/Sources/Footprint/Footprint.swift
+++ b/Sources/Footprint/Footprint.swift
@@ -292,7 +292,8 @@ public final class Footprint: @unchecked Sendable {
         guard _memoryLock.withLock({
             let hasChanges = (_memory.state != memory.state ||
                 _memory.pressure != memory.pressure ||
-                abs(_memory.used - memory.used) > 1_000_000) &&
+                abs(_memory.used - memory.used) > 1_000_000 ||
+                abs(_memory.system.remaining - memory.system.remaining) > 1_000_000) &&
                 memory.timestamp - _memory.timestamp >= _heartbeatInterval
             if hasChanges {
                 _memory = memory
@@ -324,6 +325,9 @@ public final class Footprint: @unchecked Sendable {
         }
         // memory used changes only on ~1MB intervals
         if abs(oldMemory.used - newMemory.used) > 1_000_000 {
+            changeSet.insert(.footprint)
+        }
+        if abs(oldMemory.system.remaining - newMemory.system.remaining) > 1_000_000 {
             changeSet.insert(.footprint)
         }
 

--- a/Tests/FootprintTests/FootprintTests.swift
+++ b/Tests/FootprintTests/FootprintTests.swift
@@ -8,13 +8,16 @@ class MockMemoryProvider: MemoryProvider {
     var used: Int64 = 100_000_000 // 100 MB
     var remaining: Int64 = 900_000_000 // 900 MB
     var compressed: Int64 = 0
+    var systemLimit: Int64 = 8_000_000_000 // 8 GB
+    var systemRemaining: Int64 = 4_000_000_000 // 4 GB
 
     func provide(_ pressure: Footprint.Memory.State) -> Footprint.Memory {
         Footprint.Memory(
             used: used,
             remaining: remaining,
             compressed: compressed,
-            pressure: pressure
+            pressure: pressure,
+            system: Footprint.Memory.System(limit: systemLimit, remaining: systemRemaining)
         )
     }
 }
@@ -228,6 +231,24 @@ class FootprintTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(memory.remaining, 0)
         XCTAssertGreaterThan(memory.limit, 0)
         XCTAssertEqual(memory.limit, memory.used + memory.remaining)
+    }
+
+    func testSystemMemory() {
+        let memory = Footprint.shared.memory
+
+        XCTAssertGreaterThan(memory.system.limit, 0)
+        XCTAssertGreaterThanOrEqual(memory.system.remaining, 0)
+        XCTAssertLessThanOrEqual(memory.system.remaining, memory.system.limit)
+    }
+
+    func testSystemMemoryFromMockProvider() {
+        let mock = MockMemoryProvider()
+        mock.systemLimit = 8_000_000_000
+        mock.systemRemaining = 3_000_000_000
+        let memory = mock.provide(.normal)
+
+        XCTAssertEqual(memory.system.limit, 8_000_000_000)
+        XCTAssertEqual(memory.system.remaining, 3_000_000_000)
     }
 
     // MARK: - ChangeType Tests


### PR DESCRIPTION
Exposes device-level physical memory (total and free) via a new `Footprint.Memory.System` struct populated from `host_statistics64`.