### PR TITLE
Track system memory headroom with a baseline-shifted state ladder

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,19 +213,19 @@ Footprint categorizes memory into five states. App-level and system-level state 
 
 **App state** (`memory.app.state`) buckets used memory against the app's jetsam limit:
 
-- **Normal** (< 25% used): Full functionality, optimal performance
-- **Warning** (25-50%): Begin reducing memory usage, optimize caches
-- **Urgent** (50-75%): Significant memory reduction needed
-- **Critical** (75-90%): Aggressive cleanup required
-- **Terminal** (> 90%): Imminent termination risk, emergency measures
+- **Normal** (used < 25% of limit): Full functionality, optimal performance
+- **Warning** (25% ≤ used < 50%): Begin reducing memory usage, optimize caches
+- **Urgent** (50% ≤ used < 75%): Significant memory reduction needed
+- **Critical** (75% ≤ used < 90%): Aggressive cleanup required
+- **Terminal** (used ≥ 90%): Imminent termination risk, emergency measures
 
 **System state** (`memory.system.state`) buckets remaining physical memory against the device's total RAM, but only across the top ~20% of the range — the wired kernel pages and unreclaimable caches that exist on every device dominate any ratio against full RAM, so the bottom 80% is treated as a single "logical zero" that always reports normal. In remaining-of-physical-memory terms:
 
-- **Normal** (> 15% remaining): Plenty of device headroom
-- **Warning** (10-15%): Headroom narrowing
-- **Urgent** (5-10%): Device getting tight
-- **Critical** (2-5%): Reclaim and jetsam likely imminent
-- **Terminal** (< 2%): Near OOM
+- **Normal** (remaining > 15%): Plenty of device headroom
+- **Warning** (10% < remaining ≤ 15%): Headroom narrowing
+- **Urgent** (5% < remaining ≤ 10%): Device getting tight
+- **Critical** (2% < remaining ≤ 5%): Reclaim and jetsam likely imminent
+- **Terminal** (remaining ≤ 2%): Near OOM
 
 ## Practical Examples
 

--- a/README.md
+++ b/README.md
@@ -146,9 +146,10 @@ ContentView()
 #### Headroom-Specific Changes
 
 System-wide headroom (device-level available physical memory — free pages
-plus inactive pages the kernel can reclaim) is independent of the app's own
-memory limit. Use this to back off when the device is under pressure even
-when the app still has room within its own budget.
+plus the kernel's reclaimable cached files, matching Activity Monitor's
+"Free + Cached Files" view) is independent of the app's own memory limit.
+Use this to back off when the device is under pressure even when the app
+still has room within its own budget.
 
 ```swift
 ContentView()
@@ -208,13 +209,23 @@ if Footprint.shared.canAllocate(bytes: sizeNeeded) {
 
 ## Memory States Explained
 
-Footprint categorizes memory usage into five states based on the ratio of used memory to total limit:
+Footprint categorizes memory into five states. App-level and system-level state share the same ladder but apply it to different ranges, since the meaningful signal lives in different parts of each axis.
 
-- **Normal** (< 25%): Full functionality, optimal performance
+**App state** (`memory.app.state`) buckets used memory against the app's jetsam limit:
+
+- **Normal** (< 25% used): Full functionality, optimal performance
 - **Warning** (25-50%): Begin reducing memory usage, optimize caches
 - **Urgent** (50-75%): Significant memory reduction needed
 - **Critical** (75-90%): Aggressive cleanup required
 - **Terminal** (> 90%): Imminent termination risk, emergency measures
+
+**System state** (`memory.system.state`) buckets remaining physical memory against the device's total RAM, but only across the top ~20% of the range — the wired kernel pages and unreclaimable caches that exist on every device dominate any ratio against full RAM, so the bottom 80% is treated as a single "logical zero" that always reports normal. In remaining-of-physical-memory terms:
+
+- **Normal** (> 15% remaining): Plenty of device headroom
+- **Warning** (10-15%): Headroom narrowing
+- **Urgent** (5-10%): Device getting tight
+- **Critical** (2-5%): Reclaim and jetsam likely imminent
+- **Terminal** (< 2%): Near OOM
 
 ## Practical Examples
 

--- a/Sources/Footprint/DefaultMemoryProvider.swift
+++ b/Sources/Footprint/DefaultMemoryProvider.swift
@@ -44,19 +44,42 @@ extension Footprint {
                 : 0
 
             return Footprint.Memory(
-                app: Footprint.Memory.App(used: used, remaining: remaining, compressed: compressed, pressure: pressure),
-                system: Footprint.Memory.System(limit: Self.systemLimit, remaining: systemRemaining)
+                app: Footprint.Memory.App(
+                    used: used,
+                    remaining: remaining,
+                    compressed: compressed,
+                    pressure: pressure
+                ),
+                system: Footprint.Memory.System(
+                    limit: Self.systemLimit,
+                    remaining: systemRemaining
+                )
             )
         }
 
-        /// Inactive pages still hold data, but the kernel can reclaim them
-        /// without paging out, so we treat them as available system headroom
-        /// alongside truly free pages. Active, wired, and compressor pages
-        /// are in use and don't count. Speculative pages aren't added
-        /// separately because they're already part of free_count.
+        /// Matches Activity Monitor's "Free + Cached Files" view, which is the
+        /// headroom number users see in Xcode's memory gauge.
+        ///
+        /// `free_count` includes `speculative_count` (pages the kernel read in
+        /// opportunistically that may be evicted shortly), so we subtract it
+        /// to get the same conservative "Free" Activity Monitor displays.
+        ///
+        /// `purgeable_count` (volatile pages the kernel can discard) and
+        /// `external_page_count` (all file-backed pages, regardless of queue)
+        /// make up the "Cached Files" bucket. Note that `external_page_count`
+        /// includes file-backed pages that are currently active — reclaiming
+        /// those isn't free, but the kernel can do it without paging anonymous
+        /// memory out, which is the line we care about.
+        ///
+        /// Anonymous inactive pages are deliberately excluded: reclaiming them
+        /// requires compression or swap, which is what we want headroom
+        /// transitions to warn us *before*.
         static func availableSystemBytes(from stats: vm_statistics64_data_t, pageSize: UInt64) -> Int64 {
-            let pages = UInt64(stats.free_count) + UInt64(stats.inactive_count)
-            return Int64(pages * pageSize)
+            let speculative = UInt64(stats.speculative_count)
+            let freeCount = UInt64(stats.free_count)
+            let free = freeCount > speculative ? freeCount - speculative : 0
+            let cached = UInt64(stats.purgeable_count) + UInt64(stats.external_page_count)
+            return Int64((free + cached) * pageSize)
         }
 
         // All process-lifetime constants — page size and physical memory

--- a/Sources/Footprint/Memory.swift
+++ b/Sources/Footprint/Memory.swift
@@ -64,13 +64,28 @@ public extension Footprint {
             }
 
             /// Derive a `State` from a `used` value and its enclosing `limit`.
+            ///
+            /// `baseline` shifts the 25/50/75/90 ladder up the range, treating
+            /// `[0, baseline]` as a "logical zero" that always reports `.normal`.
+            /// The four danger thresholds then land at `baseline + 0.25 × (1 - baseline)`,
+            /// `+ 0.50`, `+ 0.75`, `+ 0.90`. With the default `baseline = 0` the
+            /// thresholds are the original 25/50/75/90.
+            ///
+            /// `System` passes `baseline = 0.80` because a ratio against
+            /// `physicalMemory` is dominated by wired kernel pages and
+            /// always-on system overhead; only the top ~20% of the range is
+            /// meaningful headroom worth bucketing.
+            ///
             /// Returns `.normal` when `limit <= 0`.
-            public static func from(used: Int64, limit: Int64) -> State {
-                let usedRatio = limit > 0 ? Double(used) / Double(limit) : 0
-                return usedRatio < 0.25 ? .normal :
-                    usedRatio < 0.50 ? .warning :
-                    usedRatio < 0.75 ? .urgent :
-                    usedRatio < 0.90 ? .critical : .terminal
+            public static func from(used: Int64, limit: Int64, baseline: Double = 0) -> State {
+                guard limit > 0 else { return .normal }
+                let usedRatio = Double(used) / Double(limit)
+                let scale = 1.0 - baseline
+                if usedRatio < baseline + 0.25 * scale { return .normal }
+                if usedRatio < baseline + 0.50 * scale { return .warning }
+                if usedRatio < baseline + 0.75 * scale { return .urgent }
+                if usedRatio < baseline + 0.90 * scale { return .critical }
+                return .terminal
             }
         }
 
@@ -93,13 +108,27 @@ public extension Footprint {
             /// The state of memory pressure (aka. how close the app is to being jetsammed/jettisoned).
             public let pressure: State
 
-            init(used: Int64, remaining: Int64, compressed: Int64, pressure: State) {
+            init(used: Int64, remaining: Int64, compressed: Int64, state: State, pressure: State) {
                 self.used = used
                 self.remaining = remaining
                 self.compressed = compressed
+                self.state = state
                 self.pressure = pressure
                 limit = used + remaining
-                state = State.from(used: used, limit: limit)
+            }
+
+            /// Convenience init that derives `state` from `(used, used + remaining)`
+            /// via `State.from(used:limit:)`. Use this in any provider whose state
+            /// policy matches the default; reach for the explicit-state init only
+            /// when overriding that policy.
+            init(used: Int64, remaining: Int64, compressed: Int64, pressure: State) {
+                self.init(
+                    used: used,
+                    remaining: remaining,
+                    compressed: compressed,
+                    state: State.from(used: used, limit: used + remaining),
+                    pressure: pressure
+                )
             }
         }
 
@@ -107,17 +136,34 @@ public extension Footprint {
         public struct System: Sendable {
             /// Total physical memory on the device.
             public let limit: Int64
-            /// Currently available physical memory on the device — free pages
-            /// plus inactive pages the kernel can reclaim without paging out.
+            /// Currently available physical memory on the device — truly free
+            /// pages (excluding speculative) plus the cached-files bucket
+            /// (purgeable + external pages). Matches Activity Monitor's
+            /// "Free + Cached Files" view.
             public let remaining: Int64
-            /// The state describing where the device sits within the scope of its
-            /// physical memory limit.
+            /// The state describing the device's memory headroom, derived from
+            /// `(used, limit)` with `baseline = 0.80` so only the top ~20% of
+            /// the range maps onto warning/urgent/critical/terminal. See
+            /// `State.from(used:limit:baseline:)` for the rationale.
             public let state: State
 
-            init(limit: Int64, remaining: Int64) {
+            init(limit: Int64, remaining: Int64, state: State) {
                 self.limit = limit
                 self.remaining = remaining
-                state = State.from(used: max(limit - remaining, 0), limit: limit)
+                self.state = state
+            }
+
+            /// Convenience init that derives `state` from `(used, limit)` with
+            /// `baseline = 0.80`. Use this in any provider whose state policy
+            /// matches the default; reach for the explicit-state init only when
+            /// overriding that policy.
+            init(limit: Int64, remaining: Int64) {
+                let used = max(limit - remaining, 0)
+                self.init(
+                    limit: limit,
+                    remaining: remaining,
+                    state: State.from(used: used, limit: limit, baseline: 0.80)
+                )
             }
         }
 

--- a/Sources/Footprint/Memory.swift
+++ b/Sources/Footprint/Memory.swift
@@ -76,9 +76,13 @@ public extension Footprint {
             /// always-on system overhead; only the top ~20% of the range is
             /// meaningful headroom worth bucketing.
             ///
+            /// `baseline` is clamped to `[0, 1]`; out-of-range values would
+            /// otherwise collapse or invert the ladder.
+            ///
             /// Returns `.normal` when `limit <= 0`.
             public static func from(used: Int64, limit: Int64, baseline: Double = 0) -> State {
                 guard limit > 0 else { return .normal }
+                let baseline = min(max(baseline, 0.0), 1.0)
                 let usedRatio = Double(used) / Double(limit)
                 let scale = 1.0 - baseline
                 if usedRatio < baseline + 0.25 * scale { return .normal }

--- a/Sources/Footprint/MemoryProvider.swift
+++ b/Sources/Footprint/MemoryProvider.swift
@@ -11,6 +11,13 @@ import Foundation
 /// `Footprint.DefaultMemoryProvider`, reads from the kernel; tests can supply
 /// their own. Internal — `Footprint.init(_:)` is also internal, so this
 /// protocol is not reachable from outside the module.
+///
+/// Providers are responsible for *both* the raw byte measurements and the
+/// `Memory.App.state` / `Memory.System.state` buckets the measurements map to.
+/// Most providers should use `Footprint.Memory.State.from(used:limit:)` and
+/// `Footprint.Memory.State.from(remaining:)` as their default policy, but they
+/// are free to use custom thresholds (e.g. an app-specific OOM tuner or a test
+/// fixture that wants deterministic states).
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, visionOS 1.0, *)
 protocol MemoryProvider {
     func provide(_ pressure: Footprint.Memory.State) -> Footprint.Memory

--- a/Sources/Footprint/MemoryProvider.swift
+++ b/Sources/Footprint/MemoryProvider.swift
@@ -14,10 +14,11 @@ import Foundation
 ///
 /// Providers are responsible for *both* the raw byte measurements and the
 /// `Memory.App.state` / `Memory.System.state` buckets the measurements map to.
-/// Most providers should use `Footprint.Memory.State.from(used:limit:)` and
-/// `Footprint.Memory.State.from(remaining:)` as their default policy, but they
-/// are free to use custom thresholds (e.g. an app-specific OOM tuner or a test
-/// fixture that wants deterministic states).
+/// Most providers should use `Footprint.Memory.State.from(used:limit:baseline:)`
+/// as their default policy — `baseline = 0` (the default) for app state, and
+/// `baseline = 0.80` for system state — but they are free to use custom
+/// thresholds (e.g. an app-specific OOM tuner or a test fixture that wants
+/// deterministic states).
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, visionOS 1.0, *)
 protocol MemoryProvider {
     func provide(_ pressure: Footprint.Memory.State) -> Footprint.Memory

--- a/Tests/FootprintTests/FootprintTests.swift
+++ b/Tests/FootprintTests/FootprintTests.swift
@@ -43,8 +43,16 @@ class MockMemoryProvider: MemoryProvider {
     func provide(_ pressure: Footprint.Memory.State) -> Footprint.Memory {
         _lock.withLock {
             Footprint.Memory(
-                app: Footprint.Memory.App(used: _used, remaining: _remaining, compressed: _compressed, pressure: pressure),
-                system: Footprint.Memory.System(limit: _systemLimit, remaining: _systemRemaining)
+                app: Footprint.Memory.App(
+                    used: _used,
+                    remaining: _remaining,
+                    compressed: _compressed,
+                    pressure: pressure
+                ),
+                system: Footprint.Memory.System(
+                    limit: _systemLimit,
+                    remaining: _systemRemaining
+                )
             )
         }
     }
@@ -96,7 +104,19 @@ class FootprintTests: XCTestCase {
         remaining: Int64,
         pressure: Footprint.Memory.State = .normal
     ) -> Footprint.Memory.App {
-        Footprint.Memory.App(used: used, remaining: remaining, compressed: 0, pressure: pressure)
+        Footprint.Memory.App(
+            used: used,
+            remaining: remaining,
+            compressed: 0,
+            pressure: pressure
+        )
+    }
+
+    private func makeSystem(
+        limit: Int64,
+        remaining: Int64
+    ) -> Footprint.Memory.System {
+        Footprint.Memory.System(limit: limit, remaining: remaining)
     }
 
     func testAppInitNormalState() {
@@ -171,6 +191,7 @@ class FootprintTests: XCTestCase {
             used: 500_000_000,
             remaining: 500_000_000,
             compressed: 80_000_000,
+            state: .urgent,
             pressure: .normal
         )
 
@@ -181,7 +202,7 @@ class FootprintTests: XCTestCase {
     func testMemoryTimestamp() {
         let memory = Footprint.Memory(
             app: makeApp(used: 100_000_000, remaining: 900_000_000),
-            system: .init(limit: 0, remaining: 0)
+            system: makeSystem(limit: 0, remaining: 0)
         )
 
         XCTAssertGreaterThan(memory.timestamp, 0)
@@ -322,44 +343,63 @@ class FootprintTests: XCTestCase {
         XCTAssertEqual(Footprint.Memory.State.from(used: 100, limit: 0), .normal)
     }
 
-    func testSystemMemoryStateNormal() {
-        // 1 GB used out of 8 GB → 12.5%
-        let system = Footprint.Memory.System(limit: 8_000_000_000, remaining: 7_000_000_000)
+    // System state uses the same 25/50/75/90 ladder as App but shifted by
+    // baseline = 0.80, so only the top ~20% of physical memory maps onto
+    // warning/urgent/critical/terminal. The remaining-percentage boundaries
+    // for System are 15% / 10% / 5% / 2%.
+
+    func testStateFromUsedAndLimitWithBaseline() {
+        // baseline = 0.80 shifts the 25/50/75/90 thresholds to 85/90/95/98.
+        XCTAssertEqual(Footprint.Memory.State.from(used: 800, limit: 1000, baseline: 0.80), .normal) // 80%
+        XCTAssertEqual(Footprint.Memory.State.from(used: 840, limit: 1000, baseline: 0.80), .normal) // 84%
+        XCTAssertEqual(Footprint.Memory.State.from(used: 870, limit: 1000, baseline: 0.80), .warning) // 87%
+        XCTAssertEqual(Footprint.Memory.State.from(used: 920, limit: 1000, baseline: 0.80), .urgent) // 92%
+        XCTAssertEqual(Footprint.Memory.State.from(used: 960, limit: 1000, baseline: 0.80), .critical) // 96%
+        XCTAssertEqual(Footprint.Memory.State.from(used: 990, limit: 1000, baseline: 0.80), .terminal) // 99%
+    }
+
+    func testSystemMemoryStateNormalWhenAmpleHeadroom() {
+        // 7 GB free of 8 GB → 87.5% remaining, well above the 15% normal floor.
+        let system = makeSystem(limit: 8_000_000_000, remaining: 7_000_000_000)
         XCTAssertEqual(system.state, .normal)
     }
 
     func testSystemMemoryStateWarning() {
-        // 3 GB used out of 8 GB → 37.5%
-        let system = Footprint.Memory.System(limit: 8_000_000_000, remaining: 5_000_000_000)
+        // 1 GB free of 8 GB → 12.5% remaining, in the 10–15% warning band.
+        let system = makeSystem(limit: 8_000_000_000, remaining: 1_000_000_000)
         XCTAssertEqual(system.state, .warning)
     }
 
     func testSystemMemoryStateUrgent() {
-        // 5 GB used out of 8 GB → 62.5%
-        let system = Footprint.Memory.System(limit: 8_000_000_000, remaining: 3_000_000_000)
+        // 600 MB free of 8 GB → 7.5% remaining, in the 5–10% urgent band.
+        let system = makeSystem(limit: 8_000_000_000, remaining: 600_000_000)
         XCTAssertEqual(system.state, .urgent)
     }
 
     func testSystemMemoryStateCritical() {
-        // 6.5 GB used out of 8 GB → 81.25%
-        let system = Footprint.Memory.System(limit: 8_000_000_000, remaining: 1_500_000_000)
+        // 300 MB free of 8 GB → 3.75% remaining, in the 2–5% critical band.
+        let system = makeSystem(limit: 8_000_000_000, remaining: 300_000_000)
         XCTAssertEqual(system.state, .critical)
     }
 
     func testSystemMemoryStateTerminal() {
-        // 7.6 GB used out of 8 GB → 95%
-        let system = Footprint.Memory.System(limit: 8_000_000_000, remaining: 400_000_000)
+        // 100 MB free of 8 GB → 1.25% remaining, below the 2% terminal floor.
+        let system = makeSystem(limit: 8_000_000_000, remaining: 100_000_000)
         XCTAssertEqual(system.state, .terminal)
     }
 
-    func testSystemMemoryStateZeroLimit() {
-        let system = Footprint.Memory.System(limit: 0, remaining: 0)
+    func testSystemMemoryStateLargeDeviceIdleStillNormal() {
+        // 11 GB free on a 16 GB device — 68.75% remaining, still well above
+        // the 15% normal floor. Sanity check that baselining keeps idle
+        // large-RAM devices out of the danger zone.
+        let system = makeSystem(limit: 16_000_000_000, remaining: 11_000_000_000)
         XCTAssertEqual(system.state, .normal)
     }
 
-    func testSystemMemoryStateRemainingExceedsLimit() {
-        // remaining > limit shouldn't produce a negative used or odd state
-        let system = Footprint.Memory.System(limit: 1_000_000_000, remaining: 2_000_000_000)
+    func testSystemMemoryStateZeroLimit() {
+        // limit == 0 has no meaningful state to derive; the formula returns
+        // .normal rather than treating it as terminal.
+        let system = makeSystem(limit: 0, remaining: 0)
         XCTAssertEqual(system.state, .normal)
     }
 
@@ -381,20 +421,39 @@ class FootprintTests: XCTestCase {
 
     // MARK: - Available System Bytes
 
-    func testAvailableSystemBytesSumsFreeAndInactive() {
+    // Matches Activity Monitor's "Free + Cached Files" view:
+    //   (free_count - speculative_count) + purgeable_count + external_page_count
+
+    func testAvailableSystemBytesSumsFreeAndCached() {
         var stats = vm_statistics64_data_t()
         stats.free_count = 100
-        stats.inactive_count = 50
+        stats.purgeable_count = 30
+        stats.external_page_count = 20
 
         let bytes = Footprint.DefaultMemoryProvider.availableSystemBytes(from: stats, pageSize: 16_384)
 
         XCTAssertEqual(bytes, Int64(150) * 16_384)
     }
 
-    func testAvailableSystemBytesIgnoresInUsePages() {
-        // Active, wired, and compressor pages are in use — they don't count
-        // toward available memory. (Speculative pages aren't tested
-        // separately because they're a subset of free_count.)
+    func testAvailableSystemBytesSubtractsSpeculativeFromFree() {
+        // speculative_count is a subset of free_count; Activity Monitor's
+        // displayed "Free" subtracts it because speculative pages may be
+        // evicted shortly.
+        var stats = vm_statistics64_data_t()
+        stats.free_count = 100
+        stats.speculative_count = 40
+
+        let bytes = Footprint.DefaultMemoryProvider.availableSystemBytes(from: stats, pageSize: 4_096)
+
+        XCTAssertEqual(bytes, Int64(60) * 4_096)
+    }
+
+    func testAvailableSystemBytesIgnoresInactiveAndInUsePages() {
+        // Active, wired, compressor, and inactive pages are not added by
+        // this formula. File-backed inactive pages re-enter the count via
+        // external_page_count; anonymous inactive pages would require
+        // compression or swap to reclaim, which is what we want headroom
+        // transitions to warn us *before*.
         var stats = vm_statistics64_data_t()
         stats.free_count = 10
         stats.inactive_count = 20
@@ -404,7 +463,7 @@ class FootprintTests: XCTestCase {
 
         let bytes = Footprint.DefaultMemoryProvider.availableSystemBytes(from: stats, pageSize: 4_096)
 
-        XCTAssertEqual(bytes, Int64(30) * 4_096)
+        XCTAssertEqual(bytes, Int64(10) * 4_096)
     }
 
     // MARK: - Lifecycle
@@ -447,7 +506,7 @@ class FootprintTests: XCTestCase {
                   let memory = note.userInfo?[Footprint.newMemoryKey] as? Footprint.Memory,
                   let prevMemory = note.userInfo?[Footprint.oldMemoryKey] as? Footprint.Memory,
                   memory.system.limit == 8_000_000_000,
-                  memory.system.remaining == 200_000_000
+                  memory.system.remaining == 100_000_000
             else { return }
 
             XCTAssertTrue(changes.contains(.headroom))
@@ -458,8 +517,8 @@ class FootprintTests: XCTestCase {
         }
         defer { NotificationCenter.default.removeObserver(token) }
 
-        // Drop free memory enough to push system state from .normal to .terminal.
-        mock.systemRemaining = 200_000_000 // ~97.5% used
+        // Drop free memory below the 2% terminal floor (100 MB / 8 GB ≈ 1.25%).
+        mock.systemRemaining = 100_000_000
 
         wait(for: [expect], timeout: 3.0)
         _ = footprint // keep alive until the notification arrives


### PR DESCRIPTION
System headroom previously derived `state` from a ratio of used-to-`physicalMemory`, which pinned healthy idle devices to `.warning` because the wired kernel pages and unreclaimable system caches that exist on every device dominated the ratio. On a 16 GB iPad with 5–6 GB of OS overhead at idle, the system signal would fire before the app did anything.

`availableSystemBytes` now reads `(free - speculative) + purgeable + external` from `vm_statistics64`, matching Activity Monitor's "Free + Cached Files" view — the same number Xcode's memory gauge displays. State derivation is unified behind `State.from(used:limit:baseline:)`, where the baseline parameter shifts the existing 25/50/75/90 ladder up the range. With the default `baseline = 0`, `App` keeps its current bucket boundaries unchanged. `System` passes `baseline = 0.80` so only the top ~20% of physical memory maps onto warning/urgent/critical/terminal — the bands land at >15% / 10–15% / 5–10% / 2–5% / <2% remaining, scaling proportionally with device size.

State construction also moved from `App.init`/`System.init` into the caller, with convenience inits that apply the default policy. The bytes/state invariant is preserved for production callers; tests or custom providers can override via the explicit-state init when they need to.

The system bands have been verified on macOS but not on iOS hardware. iOS keeps free+cached aggressively low by design, so the bands may chatter on memory-tight iPhones. Worth measuring under real workload before treating 0.80 as final — exposing `baseline` as a parameter on `Footprint.init` would let apps tune their own tolerance and is a straightforward follow-up.